### PR TITLE
Add function to trace without QuasiQuote

### DIFF
--- a/src/Debug/Trace/Var.hs
+++ b/src/Debug/Trace/Var.hs
@@ -1,12 +1,18 @@
 {-# LANGUAGE QuasiQuotes     #-}
 {-# LANGUAGE TemplateHaskell #-}
-module Debug.Trace.Var (traceVar, traceVarId, traceStackVar, traceVarIO, traceVarM) where
+module Debug.Trace.Var (traceMTH, traceVar, traceVarId, traceStackVar, traceVarIO, traceVarM) where
 
 import           Data.Maybe
 import           Debug.Trace
 import           Language.Haskell.TH
 import           Language.Haskell.TH.Quote
 import           Text.Show.Unicode
+
+
+traceMTH :: Name -> Q Exp
+traceMTH name = do
+  let varName = nameBase name
+  [| traceM $ $(stringE varName) ++ $(stringE " = ") ++ ushow $(varE name) |]
 
 traceVar :: QuasiQuoter
 traceVar = traceVarBase [|trace|]


### PR DESCRIPTION
直接マージしなくても、参考までにどうぞ！
下記のようにシングルクォートで始めればローカル変数でもNameがとれるはずです。
結果 👇 のように書くことができます。

```haskell
> :set -XTemplateHaskell
> :m Debug.Trace.Var

> let b = 9 :: Int
> $(traceMTH 'b)
b = 9
```

理想的には [monad-loggerのlogDebug](https://hackage.haskell.org/package/monad-logger-0.3.28.5/docs/Control-Monad-Logger.html#v:logDebug)みたいに、

```
$logDebug "log message"
```

と書けるとよかったんですが、 `[| ... |]` の中に `[| ... |]` を書いて、TemplateHaskellが生成した結果からさらに生成する、ということができなかったはずなので、ちょっと諦めました。